### PR TITLE
Update get_string for PyUSB 1.0 which dropped the length argument

### DIFF
--- a/blinkstick.py
+++ b/blinkstick.py
@@ -240,13 +240,13 @@ class BlinkStick(object):
 
     def _usb_get_string(self, device, index):
         try:
-            return usb.util.get_string(device, 256, index)
+            return usb.util.get_string(device, index)
         except usb.USBError:
             # Could not communicate with BlinkStick device
             # attempt to find it again based on serial
 
             if self._refresh_device():
-                return usb.util.get_string(self.device, 256, index)
+                return usb.util.get_string(self.device, index)
             else:
                 raise BlinkStickException("Could not communicate with BlinkStick {0} - it may have been removed".format(self.bs_serial))
 


### PR DESCRIPTION
See https://github.com/arvydas/blinkstick-python/pull/35 and
https://stackoverflow.com/questions/5943847/get-string-descriptor-using-pyusb-usb-util-get-string
for other similar changes.